### PR TITLE
fix: odata exception handler - xml error

### DIFF
--- a/packages/generator-ui5-react/src/app/templates/src/odata/ODataExceptionHandler.ts
+++ b/packages/generator-ui5-react/src/app/templates/src/odata/ODataExceptionHandler.ts
@@ -33,7 +33,7 @@ export const getErrorMessage: ErrorMessageRetriever = error => {
         data = dataJson;
       } else if (/.*<message>(.*)<\/message>.*/.test(data)) {
         // it's XML, though => regexp parsing of message value
-        return data.replace(/.*<message>(.*)<\/message>.*/, "$1").trim();
+        return data.replace(/.*<message.*>(.*)<\/message>.*/, "$1").trim();
       }
     }
     if (typeof data !== "string") {


### PR DESCRIPTION
Supports the following case with translated message: <?xml version="1.0" encoding="utf-8"?><error xmlns="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"><code>0050569259751EE4BA9710043F8A5115</code><message xml:lang="de">Im Rahmen der Datenservices ist ein unbekannter interner Serverfehler aufgetreten</message></error>